### PR TITLE
fix: strings.Index panic

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,7 @@
+## WIP  TBD
+
+ * :hammer: Fixed buf in `strings.Indent` that caused a panic if the input string was empty.
+
 ## v0.9.0  2024-09-03
 
  * Adding `maps.Flip`, `maps.FlipSlice`, and `sets.FlipMap`.

--- a/strings/content.go
+++ b/strings/content.go
@@ -286,7 +286,7 @@ func Increment(input string) string {
 // Indent returns the string with each line indented by the given string.
 func Indent(s, indent string) string {
 	startIndent := indent
-	if s[0] == '\n' {
+	if len(s) > 0 && s[0] == '\n' {
 		startIndent = ""
 	}
 	return strings.TrimRight(

--- a/strings/content_test.go
+++ b/strings/content_test.go
@@ -93,6 +93,7 @@ func TestIncrement(t *testing.T) {
 func TestIndent(t *testing.T) {
 	t.Parallel()
 
+	assert.Equal(t, "", strings.Indent("", "    "))
 	assert.Equal(t, "\n    a\n    b\n    c\n", strings.Indent("\na\nb\nc\n", "    "))
 	assert.Equal(t, "    a\n    b\n    c", strings.Indent("a\nb\nc", "    "))
 }


### PR DESCRIPTION
This pull request addresses a bug in the `strings.Indent` function and adds a corresponding test to ensure the fix works correctly.

Bug Fix:

* [`strings/content.go`](diffhunk://#diff-bd583b8fb294ac84331aca5a28dad879f7d52848c984290cde33fb87ea2ed8f9L289-R289): Fixed a bug in `Indent` that caused a panic if the input string was empty by adding a length check before accessing the first character.

Testing:

* [`strings/content_test.go`](diffhunk://#diff-b1be59ab76dbf9c5dc725a050095c35dd671b8909d3c16c829e351549ed34dc8R96): Added a test case to `TestIndent` to verify that the `Indent` function returns an empty string when given an empty input string.

Documentation:

* [`Changes.md`](diffhunk://#diff-46efb9fafbbb11cf26bd8ac10f0bc5df02ac0e42f593b87cce382e712b8cf950R1-R4): Documented the bug fix in the `strings.Indent` function.