### PR TITLE
feat: add strings.TrimToOnly

### DIFF
--- a/.idea/golinter.xml
+++ b/.idea/golinter.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="GoLinterSettings">
+    <option name="concurrency" value="4" />
+    <option name="enabledLinters">
+      <list>
+        <option value="exportloopref" />
+        <option value="predeclared" />
+        <option value="staticcheck" />
+        <option value="govet" />
+        <option value="errorlint" />
+        <option value="misspell" />
+        <option value="errname" />
+        <option value="gocritic" />
+        <option value="errcheck" />
+        <option value="tparallel" />
+        <option value="ineffassign" />
+        <option value="unparam" />
+        <option value="nolintlint" />
+        <option value="gosec" />
+        <option value="exhaustive" />
+        <option value="gofmt" />
+        <option value="unused" />
+        <option value="whitespace" />
+        <option value="depguard" />
+        <option value="paralleltest" />
+        <option value="godot" />
+        <option value="gosimple" />
+        <option value="prealloc" />
+      </list>
+    </option>
+    <option name="goLinterExe" value="/opt/homebrew/bin/golangci-lint" />
+    <option name="linterSelected" value="true" />
+  </component>
+</project>

--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,7 @@
+## WIP  TBD
+
+ * Adding `strings.TrimToOnly`.
+
 ## v0.9.1  2024-10-15
 
  * :hammer: Fixed buf in `strings.Indent` that caused a panic if the input string was empty.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ provided tools:
 Here's a few additional operations for working with slices of bytes:
 
 * `ContainsOnly(b, chars)`
+* `TrimToOnly(b, chars)`
 * `FromRange(a, z)`
 * `Reverse(b)`
 * `Indent(b, indent)`

--- a/strings/content.go
+++ b/strings/content.go
@@ -25,7 +25,7 @@ func TrimToOnly(s string, chars string) string {
 	for _, r := range s {
 		if strings.ContainsRune(chars, r) {
 			out = append(out, r)
-			break
+			continue
 		}
 	}
 	return string(out)

--- a/strings/content.go
+++ b/strings/content.go
@@ -18,6 +18,19 @@ func ContainsOnly(s, chars string) bool {
 	}) == -1
 }
 
+// TrimToOnly returns the string with all characters removed that are not in the
+// given set of characters.
+func TrimToOnly(s string, chars string) string {
+	var out []rune
+	for _, r := range s {
+		if strings.ContainsRune(chars, r) {
+			out = append(out, r)
+			break
+		}
+	}
+	return string(out)
+}
+
 type runeSlice []rune
 
 // func (rs runeSlice) Less(i, j int) bool {

--- a/strings/content_test.go
+++ b/strings/content_test.go
@@ -17,6 +17,17 @@ func TestContainsOnly(t *testing.T) {
 	assert.False(t, strings.ContainsOnly("a b c", "abc"))
 }
 
+func TestTrimToOnly(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "abc", strings.TrimToOnly("abc", "abc"))
+	assert.Equal(t, "a", strings.TrimToOnly("a", "abc"))
+	assert.Equal(t, "aaaaaabbbbbbccccc", strings.TrimToOnly("aaaaaabbbbbbccccc", "cba"))
+	assert.Equal(t, "abc", strings.TrimToOnly("a b c", "abc"))
+	assert.Equal(t, "", strings.TrimToOnly("abc", "def"))
+	assert.Equal(t, "abde", strings.TrimToOnly("abcdef", "adbe"))
+}
+
 func TestFromRange(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
This pull request introduces a new function `TrimToOnly` to the `strings` package, updates relevant documentation, and adds new tests for this function. It also includes a new configuration file for Go linters.

New function addition:

* Added `TrimToOnly` function to `strings/content.go` which removes all characters not in the given set of characters.

Documentation updates:

* Updated `README.md` to include `TrimToOnly` in the list of provided tools.
* Updated `Changes.md` to document the addition of `TrimToOnly`.

Testing:

* Added tests for the `TrimToOnly` function in `strings/content_test.go`.

Configuration:

* Added `.idea/golinter.xml` configuration file to specify Go linter settings.